### PR TITLE
Corrigir erro de inicialização

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Frontend para o sistema de biblioteca",
   "main": "src/index.js",
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Adicionar o comando "--openssl-legacy-provider" ao script do package.json, para corrigir erro de ssl.